### PR TITLE
Add Clubs section to homepage with top 5 popular clubs

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Repository\BookRepository;
+use App\Repository\ClubRepository;
 use App\Repository\ReviewRepository;
 use App\Repository\UserBookRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -13,7 +14,7 @@ use Symfony\Component\VarDumper\VarDumper;
 class HomeController extends AbstractController
 {
     #[Route('/', name: 'home')]
-    public function index(ReviewRepository $reviewRepository, BookRepository $bookRepository, UserBookRepository $userBookRepository): Response
+    public function index(ReviewRepository $reviewRepository, BookRepository $bookRepository, UserBookRepository $userBookRepository, ClubRepository $clubRepository): Response
     {
         $reviews = $reviewRepository->findBy(
             ['status' => 'approved'],
@@ -33,12 +34,16 @@ class HomeController extends AbstractController
         }
 
         $topBooks = $bookRepository->findTopBooksByFiveStarReviews(3);
+
+        $popularClubs = $clubRepository->getMostPopular(5);
+
         return $this->render('home/index.html.twig', [
             'title' => 'Welcome to BookClub 📚',
             'reviews' => $reviews,
             'books' => $books,
             'userBooksStatus' => $userBooksStatus,
             'topBooks' => $topBooks,
+            'popularClubs' => $popularClubs,
         ]);
     }
 }

--- a/src/Repository/ClubRepository.php
+++ b/src/Repository/ClubRepository.php
@@ -31,4 +31,16 @@ class ClubRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    public function getMostPopular(int $limit = 5): array
+    {
+        return $this->createQueryBuilder('c')
+            ->leftJoin('c.members', 'm')
+            ->addSelect('COUNT(m) AS HIDDEN memberCount')
+            ->groupBy('c.id')
+            ->orderBy('memberCount', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -114,6 +114,40 @@
         <p>No books yet.</p>
     {% endif %}
     <hr>
-    <h2><a href="{{ path("club_index") }}">Clubs</a> </h2>
-    <p>Coming soon...</p>
+    <section class="mt-5">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h2>Clubs</h2>
+            <a href="{{ path('club_index') }}" class="btn btn-sm btn-outline-primary">See all</a>
+        </div>
+
+        <div class="row">
+            {% for club in popularClubs %}
+                <div class="col-md-4 mb-3">
+                    <div class="card h-100 shadow-sm">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                <a href="{{ path('club_show', {id: club.id}) }}" class="text-decoration-none">
+                                    {{ club.name }}
+                                </a>
+                            </h5>
+                            <p class="card-text text-muted">
+                                {{ club.description|length > 100 ? club.description|slice(0, 100) ~ '...' : club.description }}
+                            </p>
+
+                            {% if app.user and not club.members.contains(app.user) %}
+                                <form method="post" action="{{ path('club_join', {id: club.id}) }}">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('join' ~ club.id) }}">
+                                    <button class="btn btn-sm btn-primary">Join Club</button>
+                                </form>
+                            {% else %}
+                                <span class="badge bg-success">Member</span>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            {% else %}
+                <p>No clubs available yet.</p>
+            {% endfor %}
+        </div>
+    </section>
 {% endblock %}


### PR DESCRIPTION
### Changes
- Added query in ClubRepository to fetch the top 5 most popular clubs by member count.
- Updated HomeController to include these clubs in the homepage rendering.
- Replaced the previous "Clubs - Coming soon" placeholder with a new section.
- Each club card shows:
  - Club name (clickable → club_show).
  - Short description (truncated).
  - "Join Club" button if the user is not a member, otherwise a badge indicating membership.
- Added "Clubs" title clickable to club/index and a "See all" button.